### PR TITLE
Use FIFO for client parameters

### DIFF
--- a/cliente.c
+++ b/cliente.c
@@ -22,7 +22,7 @@ int llega12 = 0, llega14 = 0, llega10 = 0, pidbus;
 
 int main() {
 
-  int colagrafica, llega, sale, colaparada, tuberia;
+  int colagrafica, llega, sale, colaparada, fparam;
   struct tipo_parada pasajero;
   char nombrefifo[10];
   int fifosalir, testigo = 1;
@@ -37,14 +37,14 @@ int main() {
   colagrafica = crea_cola(ftok("./fichcola.txt", 18));
   colaparada = crea_cola(ftok("./fichcola.txt", 20));
 
-  // movemos la pipe a otra posicion y recuperamos la salida de errores
-  tuberia = dup(2);
+  // movemos la fifo a otra posicion y recuperamos la salida de errores
+  fparam = dup(2);
   close(2);
   open("/dev/tty", O_WRONLY);
-  // Leemos los parametros desde la pipe
-  read(tuberia, &params, sizeof(params));
-  // Leemos el pid del bus desde la pipe
-  read(tuberia, &pidbus, sizeof(pidbus));
+  // Leemos los parametros desde la fifo
+  read(fparam, &params, sizeof(params));
+  // Leemos el pid del bus desde la fifo
+  read(fparam, &pidbus, sizeof(pidbus));
 
   // Generamos aleatoriamente la parada de llegada y la de salida
   srand(getpid());

--- a/principal.c
+++ b/principal.c
@@ -28,7 +28,7 @@ int llega10 = 0;
 int main() {
 
   int pservidorgraf, i, pidbus;
-  int tubocliente[2], tubobus[2];
+  int fifoparam, tubobus[2];
   char nombrefifo[10];
   int fifos[7];
 
@@ -62,9 +62,15 @@ int main() {
       perror("Errro al abrir la fifo");
   }
 
-  // Creamos las pipes para los parametos de bus y cliente
+  // Creamos la pipe para los parametros del bus
   pipe(tubobus);
-  pipe(tubocliente);
+  // Creamos la fifo para los parametros de los clientes
+  unlink("fifocliente");
+  if (mkfifo("fifocliente", 0600) == -1)
+    perror("Error al crear fifo parametros");
+  fifoparam = open("fifocliente", O_RDWR);
+  if (fifoparam == -1)
+    perror("Error al abrir fifo parametros");
 
   // Creamos el proceso bus, pasandole la lectura de la pipe
   pidbus = creaproceso("bus", tubobus[0]);
@@ -73,13 +79,13 @@ int main() {
     perror("error al escribir parametros al bus");
 
   for (i = 1; i <= maxclientes; i++) {
-    // Creamos el proceso cliente, pasandole la lectura de la pipe
-    creaproceso("cliente", tubocliente[0]);
-    // Escribimos los parametros al cliente, por la pipe
-    if (write(tubocliente[1], &paramclientes, sizeof(paramclientes)) == -1)
+    // Creamos el proceso cliente, pasandole la fifo de parametros
+    creaproceso("cliente", fifoparam);
+    // Escribimos los parametros al cliente por la fifo
+    if (write(fifoparam, &paramclientes, sizeof(paramclientes)) == -1)
       perror("error al escribir parametros al cliente");
     // pasamos también el pid del proceso bus
-    if (write(tubocliente[1], &pidbus, sizeof(pidbus)) == -1)
+    if (write(fifoparam, &pidbus, sizeof(pidbus)) == -1)
       perror("error al escribir pid del bus al cliente");
     sleep(rand() % (creamax - creamin + 1) + creamin);
   }
@@ -107,6 +113,8 @@ int main() {
     close(fifos[i]);
     unlink(nombrefifo);
   }
+  close(fifoparam);
+  unlink("fifocliente");
 
   //Esperar la finalizacion del servidor grafico y el bus	
   wait(NULL);


### PR DESCRIPTION
## Summary
- replace the pipe used for passing parameters to clients with a FIFO
- adjust client code to read parameters from the FIFO

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68407caa2eec832eb71735a0512f2505